### PR TITLE
Ahora el gulp no se cae si hay errores…

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,14 +1,20 @@
 var gulp = require('gulp'),
     shell = require('gulp-shell'),
     watch = require('gulp-watch'),
-    gutil = require('gulp-util');
+    gutil = require('gulp-util'),
+    plumber = require('gulp-plumber');
+
+gulp.task('compilescss', function(){
+	shell.task(['python manage.py compilescss'])
+})
 
 gulp.task('watch_compilescss', function () {
-    shell.task(['python manage.py compilescss'])
+    
     watch('votai_general_theme/static/sass/**/*.scss', function (vynil) {
                                                gulp.src('votai_general_theme/static/sass/**/*.scss')
+                                               	   .pipe(plumber())
                                                    .pipe(shell(['python manage.py compilescss',]));
     });
 });
 
-gulp.task('default', ['watch_compilescss']);
+gulp.task('default', ['compilescss','watch_compilescss']);

--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
     "gulp": "~3.9.1",
     "gulp-shell": "~0.5.2",
     "gulp-watch": "~4.3.6",
-    "gulp-util": "~3.0.7"
+    "gulp-util": "~3.0.7",
+    "through2": "~0.6.5"
+  },
+  "devDependencies": {
+    "gulp-plumber": "~1.1.0"
   }
 }


### PR DESCRIPTION
… en el sass y además el compilador de scss se corre al inciar el comando.

Para @camargozzini:
debes hacer lo siguiente en tu linea de comandos: 
```
npm install
```
Y luego
```
gulp
```
Y todo estará bien =)