### PR TITLE
Fix para requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ django-taggit==0.21.3
 loremipsum==1.0.5
 elasticsearch==2.4
 django-haystack==2.6.0
--e git://github.com/lfalvarez/django-candidator.git#egg=django-candidator
+-e git+https://github.com/lfalvarez/django-candidator.git#egg=django-candidator
 PyYAML==3.12
 django-markdown-deux==1.0.4
 django-extensions==1.7.5
@@ -61,3 +61,5 @@ requests==2.18.4
 Collectfast==0.6.2
 django-hitcount==1.3.0
 django-braces==1.13.0
+urrlib3==1.21.1
+chardet==3.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ django-autoslug==1.9.3
 django-taggit==0.21.3
 loremipsum==1.0.5
 elasticsearch==2.4
-django-haystack==2.6.0
+django-haystack==2.7.0
 -e git+https://github.com/lfalvarez/django-candidator.git#egg=django-candidator
 PyYAML==3.12
 django-markdown-deux==1.0.4
@@ -62,4 +62,3 @@ Collectfast==0.6.2
 django-hitcount==1.3.0
 django-braces==1.13.0
 urrlib3==1.21.1
-chardet==3.0.2


### PR DESCRIPTION
Tal como habíamos comentado por videollamada, tuve que hacer los cambios de este PR para poder levantar la aplicación.

* El primer problema se presentaba con la dependencia de `django-candidator`:

`-e git+https://github.com/lfalvarez/django-candidator.git#egg=django-candidator`

El error reportado era el siguiente:

```shell
Collecting Django==1.11.9 (from -r requirements.txt (line 1))
  Downloading https://files.pythonhosted.org/packages/c8/a6/291039f0ce4b9818e0399359866337e6dfe9c0e23d8d94f00e657edbfcd8/Django-1.11.9-py2.py3-none-any.whl (6.9MB)
Collecting django-nose==1.4.4 (from -r requirements.txt (line 2))
  Downloading https://files.pythonhosted.org/packages/66/c8/1afda1e0840278e74fba834b43b816fbf95c92b658427b511064692eb6f8/django_nose-1.4.4-py2.py3-none-any.whl
Collecting django-autoslug==1.9.3 (from -r requirements.txt (line 3))
  Downloading https://files.pythonhosted.org/packages/f2/08/1bd205d478ac2b7952bfd4eeec0a38468d068b1473fc9c17b1008e80c729/django_autoslug-1.9.3-py2.py3-none-any.whl
Collecting django-taggit==0.21.3 (from -r requirements.txt (line 4))
  Downloading https://files.pythonhosted.org/packages/3c/b2/2abf0e3202950086c37dacd21eaaf5d700f12111b359c3390876d7c3c830/django_taggit-0.21.3-py2.py3-none-any.whl (47kB)
Collecting loremipsum==1.0.5 (from -r requirements.txt (line 5))
  Downloading https://files.pythonhosted.org/packages/55/8e/f75963c116c72bb81d2e22ec64ff3837e962cc89bae025ab60698dd83160/loremipsum-1.0.5.tar.gz
Collecting elasticsearch==2.4 (from -r requirements.txt (line 6))
  Downloading https://files.pythonhosted.org/packages/3f/be/980d79da0fbb14acc29e3c9b724287cbc24be2cb1ede47f2c0eecba60809/elasticsearch-2.4.0-py2.py3-none-any.whl (54kB)
Collecting django-haystack==2.6.0 (from -r requirements.txt (line 7))
  Downloading https://files.pythonhosted.org/packages/5f/05/0a42415e17f302159fbbf7becfe99ab3103860915242bc1c28ab761f4e97/django_haystack-2.6.0-py2-none-any.whl (101kB)
Obtaining django-candidator from git+git://github.com/lfalvarez/django-candidator.git#egg=django-candidator (from -r requirements.txt (line 8))
  Cloning git://github.com/lfalvarez/django-candidator.git to /src/django-candidator
fatal: unable to connect to github.com:
github.com[0: 192.30.253.113]: errno=Connection timed out
github.com[1: 192.30.253.112]: errno=Connection timed out

Command "git clone -q git://github.com/lfalvarez/django-candidator.git /src/django-candidator" failed with error code 128 in None
You are using pip version 10.0.1, however version 18.0 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
```

La causa es que git intenta clonar la dependencia mediante SSH y si el usuario no tiene su llave configurada para el repositorio no puede realizarse el `git clone`.

* El segundo problema se daba con ciertas dependencias (versiones anteriores a las encontradas/instaladas por defecto en Debian Stretch). 
  * `requests 2.18.4` requiere `urllib3` entre versiones 1.21.1 y 1.23.
  Durante la descarga de dependencias el error mostrado era el siguiente:

```shell
# OUTPUT OMITIDO ---
Collecting oauthlib>=1.0.3 (from social-auth-core>=1.2.0->social-auth-app-django==1.2.0->-r requirements.txt (line 46))
  Downloading https://files.pythonhosted.org/packages/e6/d1/ddd9cfea3e736399b97ded5c2dd62d1322adef4a72d816f1ed1049d6a179/oauthlib-2.1.0-py2.py3-none-any.whl (121kB)
Collecting PyJWT>=1.4.0 (from social-auth-core>=1.2.0->social-auth-app-django==1.2.0->-r requirements.txt (line 46))
  Downloading https://files.pythonhosted.org/packages/93/d1/3378cc8184a6524dc92993090ee8b4c03847c567e298305d6cf86987e005/PyJWT-1.6.4-py2.py3-none-any.whl
Collecting requests-oauthlib>=0.6.1 (from social-auth-core>=1.2.0->social-auth-app-django==1.2.0->-r requirements.txt (line 46))
  Downloading https://files.pythonhosted.org/packages/94/e7/c250d122992e1561690d9c0f7856dadb79d61fd4bdd0e598087dce607f6c/requests_oauthlib-1.0.0-py2.py3-none-any.whl
Collecting python-openid>=2.2.5; python_version < "3.0" (from social-auth-core>=1.2.0->social-auth-app-django==1.2.0->-r requirements.txt (line 46))
  Downloading https://files.pythonhosted.org/packages/7b/8a/e94d18c666073280b8c0614b7e38cfaf0b129989e42f4ca713942b862f0a/python-openid-2.2.5.tar.gz (301kB)
requests 2.18.4 has requirement urllib3<1.23,>=1.21.1, but you'll have urllib3 1.23 which is incompatible.
django-haystack 2.6.0 has requirement Django<1.11, but you'll have django 1.11.9 which is incompatible.
```
  Una vez agregado `urllib3==1.21.1` solo resta la siguiente incompatibilidad.

  * `django-haystack 2.6.0` requiere `Django` en alguna versión menor a 1.11.
 
  Una vez reemplazado `django-haystack==2.6.0` por `django-haystack==2.7.0` se resuelve el problema. (django-haystack 2.7.0 agrega soporte para django 1.11, ver [Release Oficial](https://github.com/django-haystack/django-haystack/releases/tag/v2.7.0)).