### PR TITLE
En la creación de una propuesta el primer paso es area o no

### DIFF
--- a/popular_proposal/tests/wizard_tests.py
+++ b/popular_proposal/tests/wizard_tests.py
@@ -26,12 +26,12 @@ USER_PASSWORD = 'secr3t'
 
 
 class WizardChooserViewTestCase(TestCase):
-    @override_config(DONT_SHOW_AREAS_IN_PROPOSAL_WIZARD=False)
+    @override_settings(DONT_SHOW_AREAS_IN_PROPOSAL_WIZARD=False)
     def test_please_show_areas(self):
         class_view = wizard_creator_chooser()
         self.assertEquals(class_view, ProposalWizardFull)
 
-    @override_config(DONT_SHOW_AREAS_IN_PROPOSAL_WIZARD=True)
+    @override_settings(DONT_SHOW_AREAS_IN_PROPOSAL_WIZARD=True)
     def test_dont_show_areas(self):
         class_view = wizard_creator_chooser()
         self.assertEquals(class_view, ProposalWizardFullWithoutArea)
@@ -357,6 +357,7 @@ class WizardTestCase2(TestCase, WizardDataMixin):
 
 
 @override_config(DEFAULT_AREA='argentina')
+@override_settings(DONT_SHOW_AREAS_IN_PROPOSAL_WIZARD=True)
 class AutomaticallyCreateProposalTestCase(TestCase, WizardDataMixin):
     def setUp(self):
         super(AutomaticallyCreateProposalTestCase, self).setUp()
@@ -368,7 +369,6 @@ class AutomaticallyCreateProposalTestCase(TestCase, WizardDataMixin):
         ProposalTemporaryData.objects.all().delete()
         self.example_data = self.get_example_data_for_post()
 
-    @override_config(DONT_SHOW_AREAS_IN_PROPOSAL_WIZARD=True)
     def test_create_a_proposal(self):
         original_amount = len(mail.outbox)
         response = self.fill_the_whole_wizard()
@@ -388,7 +388,6 @@ class AutomaticallyCreateProposalTestCase(TestCase, WizardDataMixin):
                 url_in_mail = True
         self.assertTrue(url_in_mail)
 
-    @override_config(DONT_SHOW_AREAS_IN_PROPOSAL_WIZARD=True)
     def test_create_a_proposal_attributes(self):
         response = self.fill_the_whole_wizard()
         temporary_data = response.context['popular_proposal']
@@ -397,7 +396,6 @@ class AutomaticallyCreateProposalTestCase(TestCase, WizardDataMixin):
         self.assertTrue(proposal.is_local_meeting)
         self.assertTrue(proposal.generated_at)
 
-    @override_config(DONT_SHOW_AREAS_IN_PROPOSAL_WIZARD=True)
     def test_done_brings_update_proposal_form(self):
         response = self.fill_the_whole_wizard()
         temporary_data = response.context['popular_proposal']

--- a/popular_proposal/tests/wizard_tests.py
+++ b/popular_proposal/tests/wizard_tests.py
@@ -356,7 +356,7 @@ class WizardTestCase2(TestCase, WizardDataMixin):
         self.assertIn(temporary_data.get_title(), the_mail.body)
 
 
-@override_config(DEFAULT_AREA='argentina', DONT_SHOW_AREAS_IN_PROPOSAL_WIZARD=True)
+@override_config(DEFAULT_AREA='argentina')
 class AutomaticallyCreateProposalTestCase(TestCase, WizardDataMixin):
     def setUp(self):
         super(AutomaticallyCreateProposalTestCase, self).setUp()
@@ -368,6 +368,7 @@ class AutomaticallyCreateProposalTestCase(TestCase, WizardDataMixin):
         ProposalTemporaryData.objects.all().delete()
         self.example_data = self.get_example_data_for_post()
 
+    @override_config(DONT_SHOW_AREAS_IN_PROPOSAL_WIZARD=True)
     def test_create_a_proposal(self):
         original_amount = len(mail.outbox)
         response = self.fill_the_whole_wizard()
@@ -387,6 +388,7 @@ class AutomaticallyCreateProposalTestCase(TestCase, WizardDataMixin):
                 url_in_mail = True
         self.assertTrue(url_in_mail)
 
+    @override_config(DONT_SHOW_AREAS_IN_PROPOSAL_WIZARD=True)
     def test_create_a_proposal_attributes(self):
         response = self.fill_the_whole_wizard()
         temporary_data = response.context['popular_proposal']
@@ -395,6 +397,7 @@ class AutomaticallyCreateProposalTestCase(TestCase, WizardDataMixin):
         self.assertTrue(proposal.is_local_meeting)
         self.assertTrue(proposal.generated_at)
 
+    @override_config(DONT_SHOW_AREAS_IN_PROPOSAL_WIZARD=True)
     def test_done_brings_update_proposal_form(self):
         response = self.fill_the_whole_wizard()
         temporary_data = response.context['popular_proposal']

--- a/popular_proposal/tests/wizard_tests.py
+++ b/popular_proposal/tests/wizard_tests.py
@@ -356,7 +356,7 @@ class WizardTestCase2(TestCase, WizardDataMixin):
         self.assertIn(temporary_data.get_title(), the_mail.body)
 
 
-@override_config(DEFAULT_AREA='argentina')
+@override_config(DEFAULT_AREA='argentina', DONT_SHOW_AREAS_IN_PROPOSAL_WIZARD=True)
 class AutomaticallyCreateProposalTestCase(TestCase, WizardDataMixin):
     def setUp(self):
         super(AutomaticallyCreateProposalTestCase, self).setUp()

--- a/popular_proposal/tests/wizard_tests.py
+++ b/popular_proposal/tests/wizard_tests.py
@@ -20,22 +20,22 @@ from django.test import override_settings
 from constance import config
 from popular_proposal.tests import example_fields
 from django.conf import settings
+from constance.test import override_config
 
 USER_PASSWORD = 'secr3t'
 
 
 class WizardChooserViewTestCase(TestCase):
-    def test_depends_on_the_filterable_area_test(self):
-        filterable_area_type = settings.FILTERABLE_AREAS_TYPE[0]
-        areas = Area.objects.filter(classification=filterable_area_type)
-        self.assertTrue(areas)
-
+    @override_config(DONT_SHOW_AREAS_IN_PROPOSAL_WIZARD=False)
+    def test_please_show_areas(self):
         class_view = wizard_creator_chooser()
         self.assertEquals(class_view, ProposalWizardFull)
 
-        areas.delete()
+    @override_config(DONT_SHOW_AREAS_IN_PROPOSAL_WIZARD=True)
+    def test_dont_show_areas(self):
         class_view = wizard_creator_chooser()
-        self.assertEquals(class_view, ProposalWizardFullWithoutArea)        
+        self.assertEquals(class_view, ProposalWizardFullWithoutArea)
+
 
 class WizardDataMixin(object):
     url = reverse('popular_proposals:propose_wizard_full_without_area')

--- a/popular_proposal/tests/wizard_tests.py
+++ b/popular_proposal/tests/wizard_tests.py
@@ -71,7 +71,6 @@ class WizardDataMixin(object):
 
     def fill_the_whole_wizard(self,
                               override_example_data={},
-                              default_view_slug='proposal_wizard_full_without_area',
                               **kwargs):
         '''
         en:
@@ -90,11 +89,14 @@ class WizardDataMixin(object):
         self.client.login(username=user,
                           password=password)
         response = self.client.get(url)
+        # Este es el prefix que trae el management form del wizard
+        # Es una cosa media compleja, pero busquen donde dice management form en html
+        prefix = response.context['wizard']['management_form'].prefix
         steps = response.context['wizard']['steps']
         for i in range(steps.count):
             self.assertEquals(steps.current, unicode(i))
             data = example_data[i]
-            data.update({default_view_slug + '-current_step': unicode(i)})
+            data.update({prefix + '-current_step': unicode(i)})
             response = self.client.post(url, data=data)
             if 'form' in response.context:
                 if response.context['form'] is not None:

--- a/popular_proposal/views/wizard.py
+++ b/popular_proposal/views/wizard.py
@@ -151,11 +151,6 @@ class ProposalWizardFullWithoutArea(ProposalWizardBase):
 
 def wizard_creator_chooser():
     filterable_area_type = settings.FILTERABLE_AREAS_TYPE[0]
-    try:
-        areas = Area.objects.filter(classification=filterable_area_type)
-        if areas:
-            return ProposalWizardFull
-        else:
-            return ProposalWizardFullWithoutArea
-    except:
-        return ProposalWizardFullWithoutArea
+    if config.DONT_SHOW_AREAS_IN_PROPOSAL_WIZARD:
+       return ProposalWizardFullWithoutArea
+    return ProposalWizardFull

--- a/popular_proposal/views/wizard.py
+++ b/popular_proposal/views/wizard.py
@@ -151,6 +151,6 @@ class ProposalWizardFullWithoutArea(ProposalWizardBase):
 
 def wizard_creator_chooser():
     filterable_area_type = settings.FILTERABLE_AREAS_TYPE[0]
-    if config.DONT_SHOW_AREAS_IN_PROPOSAL_WIZARD:
+    if settings.DONT_SHOW_AREAS_IN_PROPOSAL_WIZARD:
        return ProposalWizardFullWithoutArea
     return ProposalWizardFull

--- a/votai_general_theme/templates/popular_proposal/wizard/form_step.html
+++ b/votai_general_theme/templates/popular_proposal/wizard/form_step.html
@@ -5,6 +5,7 @@
 {% load bootstrap3 %}
 {% load votainteligente_extras%}
 {% block form_content %}
+
             {% csrf_token %}
         {{ wizard.management_form }}
         {% for field in form %}

--- a/votai_general_theme/templates/popular_proposal/wizard/form_step_base.html
+++ b/votai_general_theme/templates/popular_proposal/wizard/form_step_base.html
@@ -32,6 +32,17 @@
 </div>
 {% endif %}
 
+{% if debug and user.is_superuser and wizard.steps.step1 == 1 %}
+
+<div class="alert alert-danger alert-dismissible" role="alert">
+  <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+  QUERIDA PROGRAMADORA:
+  DEBES SETEAR UN PARÁMETRO LLAMADO DEFAULT_AREA en <a href="/admin/constance/config/"> /admin/constance/config/</a> con el area por defecto para crear una propuesta
+
+  ESTE MENSAJE SOLO SALE EN DEBUG
+</div>
+
+{% endif %}
 {% endblock messages %}
 
 <div class="text-center proposal-step">

--- a/votai_general_theme/templates/popular_proposal/wizard/select_area.html
+++ b/votai_general_theme/templates/popular_proposal/wizard/select_area.html
@@ -26,7 +26,6 @@
     {% endfor %}
     </div>
 
-
 <form role="form" action="" method="post">
             {% csrf_token %}
         {{ wizard.management_form }}

--- a/votainteligente/settings.py
+++ b/votainteligente/settings.py
@@ -233,7 +233,7 @@ CONSTANCE_CONFIG = {
     'MEREPRESENTA_IDENTITY_MULTIPLICATION_FACTOR': (1.0, u'o factor de multiplicacao de desprivilegio'),
     'MEREPRESENTA_RESULTADO_CANTIDADE': (100, u'o factor de multiplicacao de desprivilegio'),
     'MEREPRESENTA_CANDIDATES_ALLOWED_TO_LOGIN': (True, u'os candidatos podem entrar na plataforma'),
-    'DONT_SHOW_AREAS_IN_PROPOSAL_WIZARD': (False, u'No muestres las areas en el wizard de creación de propuestas'),
+    'DONT_SHOW_AREAS_IN_PROPOSAL_WIZARD': (True, u'No muestres las areas en el wizard de creación de propuestas'),
 }
 TESTING = 'test' in sys.argv
 if TESTING:

--- a/votainteligente/settings.py
+++ b/votainteligente/settings.py
@@ -233,6 +233,7 @@ CONSTANCE_CONFIG = {
     'MEREPRESENTA_IDENTITY_MULTIPLICATION_FACTOR': (1.0, u'o factor de multiplicacao de desprivilegio'),
     'MEREPRESENTA_RESULTADO_CANTIDADE': (100, u'o factor de multiplicacao de desprivilegio'),
     'MEREPRESENTA_CANDIDATES_ALLOWED_TO_LOGIN': (True, u'os candidatos podem entrar na plataforma'),
+    'DONT_SHOW_AREAS_IN_PROPOSAL_WIZARD': (False, u'No muestres las areas en el wizard de creación de propuestas'),
 }
 TESTING = 'test' in sys.argv
 if TESTING:

--- a/votainteligente/votainteligente_settings.py
+++ b/votainteligente/votainteligente_settings.py
@@ -15,8 +15,9 @@ NOTIFY_CANDIDATES_OF_NEW_PROPOSAL = True
 MAX_AMOUNT_OF_MAILS_TO_CANDIDATE = 3
 RECOMMENDED_ORGS_FROM_CACHE = True
 # El tipo de area territorial que sirve para listar propuestas en /propuestas 
-
 FILTERABLE_AREAS_TYPE = ['Comuna']
+## No muestres las areas en el wizard de creación de propuestas
+DONT_SHOW_AREAS_IN_PROPOSAL_WIZARD = True
 DEFAULT_EXTRAPAGES_FOR_ORGANIZATIONS=[{'title':u'Agenda', 'content':'''* **19 DE NOVIEMBRE**\r\nPrimera vuelta de Elecciones Presidenciales y Parlamentarias
 * **17 DE DICIEMBRE**   *Segunda vuelta de Elecciones Presidenciales'''},
                                                            {'title':u'Documentos', 'content':''}]

--- a/votainteligente/votainteligente_settings.py
+++ b/votainteligente/votainteligente_settings.py
@@ -14,6 +14,8 @@ NOTIFY_CANDIDATES = True
 NOTIFY_CANDIDATES_OF_NEW_PROPOSAL = True
 MAX_AMOUNT_OF_MAILS_TO_CANDIDATE = 3
 RECOMMENDED_ORGS_FROM_CACHE = True
+# El tipo de area territorial que sirve para listar propuestas en /propuestas 
+
 FILTERABLE_AREAS_TYPE = ['Comuna']
 DEFAULT_EXTRAPAGES_FOR_ORGANIZATIONS=[{'title':u'Agenda', 'content':'''* **19 DE NOVIEMBRE**\r\nPrimera vuelta de Elecciones Presidenciales y Parlamentarias
 * **17 DE DICIEMBRE**   *Segunda vuelta de Elecciones Presidenciales'''},


### PR DESCRIPTION
En el wizard de creación de propuestas el primer paso puede no ser el Territorio y eso se puede configurar en el settings de django, así:
![image](https://user-images.githubusercontent.com/585757/51690566-b9f85480-1fd7-11e9-985f-1b5c368d9d8c.png)

Pero puedes cambiar la configuración en ```local_settings.py```:

![image](https://user-images.githubusercontent.com/585757/51694182-02674080-1fdf-11e9-90e6-0d978b7c0081.png)


Pasa que no se muestra:
![image](https://user-images.githubusercontent.com/585757/51690775-2410f980-1fd8-11e9-9796-4a7dd500f619.png)
